### PR TITLE
Update install_deps.bash

### DIFF
--- a/atl_ros/package.xml
+++ b/atl_ros/package.xml
@@ -19,6 +19,7 @@
   <build_depend>tf</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>dji_sdk</build_depend>
   <build_depend>atl_core</build_depend>
   <build_depend>atl_msgs</build_depend>
 
@@ -31,6 +32,7 @@
   <run_depend>tf</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>dji_sdk</run_depend>
   <run_depend>atl_core</run_depend>
   <run_depend>atl_msgs</run_depend>
 

--- a/scripts/install/gazebo8_install.bash
+++ b/scripts/install/gazebo8_install.bash
@@ -4,6 +4,7 @@ UBUNTU_NAME=`lsb_release -cs`
 APT_SRC_URL=http://packages.osrfoundation.org/gazebo/ubuntu-stable
 APT_SRC_LIST=/etc/apt/sources.list.d
 GAZEBO_SRC_LIST=$APT_SRC_LIST/gazebo-stable.list
+ROS_VERSION="kinetic"
 
 install_gazebo8()
 {
@@ -14,8 +15,7 @@ install_gazebo8()
   wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 
   # install gazebo
-  sudo apt-get update
-  sudo apt-get install gazebo8
+  sudo apt-get update && apt-get install -qq -y ros-$ROS_VERSION-gazebo8-ros-pkgs
 }
 
 

--- a/scripts/install/install_deps.bash
+++ b/scripts/install/install_deps.bash
@@ -24,13 +24,13 @@ sudo apt-get install -qq -y \
 
 # setup catkin workspace
 if [ ! -d $CATKIN_PATH ]; then
-    mkdir -p $CATKIN_PATH
+    mkdir -p $CATKIN_PATH/src
     cd $CATKIN_PATH
     catkin init
     cd -
 fi
 
-# intall dependencies
+# install dependencies
 sudo bash $SCRIPT_PATH/gazebo8_install.bash
 sudo bash $SCRIPT_PATH/opencv3_install.bash
 sudo bash $SCRIPT_PATH/apriltags_michigan_install.bash

--- a/scripts/install/opencv3_install.bash
+++ b/scripts/install/opencv3_install.bash
@@ -69,6 +69,6 @@ install_opencv() {
 }
 
 # MAIN
-# install_dependencies
-# download_opencv
+install_dependencies
+download_opencv
 install_opencv

--- a/scripts/install/pointgrey_install.bash
+++ b/scripts/install/pointgrey_install.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e  # halt on first error
-PACKAGE_DIR="$(git rev-parse --show-toplevel)/atl_deps"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR=$(dirname "$SCRIPT_DIR")
+PACKAGE_DIR="${REPO_DIR}/../atl_deps"
 
 install_pointgrey_x86_drivers()
 {

--- a/scripts/install/pointgrey_install.bash
+++ b/scripts/install/pointgrey_install.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e  # halt on first error
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-REPO_DIR=$(dirname "$SCRIPT_DIR")
-PACKAGE_DIR="${REPO_DIR}/../atl_deps"
+REPO_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")  # this script is in repo/scripts/install/
+PACKAGE_DIR="${REPO_DIR}/atl_deps"
 
 install_pointgrey_x86_drivers()
 {

--- a/scripts/install/pointgrey_install.bash
+++ b/scripts/install/pointgrey_install.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e  # halt on first error
-PACKAGE_DIR=$PWD/atl_deps
+PACKAGE_DIR="$(git rev-parse --show-toplevel)/atl_deps"
 
 install_pointgrey_x86_drivers()
 {


### PR DESCRIPTION
Updates the install_deps.bash script to run on a clean `ros-kinetic-desktop-full` install.
- Adds dji_sdk as a dependency of atl_ros to guarantee build success.
- Installs the correct package for Gazebo 8 for building atl_gazebo and running Gazebo 8.
- Allows `pointgrey_install.bash` to be run from anywhere.